### PR TITLE
fixed width problem for .hero

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -195,7 +195,7 @@ ul {
 
 .hero {
 	height: 85%;
-	width: 100vw;
+	width: 100%;
 	position: relative;
 	overflow: hidden;
 }


### PR DESCRIPTION
100vw does not account for eventual horizontal scrollbars, but renders to the full width, which results in an unnecessary vertical scrollbar.

This change should most likely also be made in the master branch at ```/pages/settings/settings.css``` but as this page also has overflow:hidden, I thought I'd leave it like that for now.