### PR TITLE
Add a tasks overlay

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,6 @@ module.exports = function (grunt) {
 							"js/navbar/tabColor.js",
 						 "js/navbar/navbarTabs.js",
 							"js/taskOverlay.js",
-							"js/navbar/expandedTabMode.js",
 							"js/navbar/addTabButton.js",
 						 "js/keybindings.js",
 						 "js/fileDownloadManager.js",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function (grunt) {
 						 "js/navbar/tabActivity.js",
 							"js/navbar/tabColor.js",
 						 "js/navbar/navbarTabs.js",
+							"js/taskOverlay.js",
 							"js/navbar/expandedTabMode.js",
 							"js/navbar/addTabButton.js",
 						 "js/keybindings.js",

--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -155,7 +155,6 @@ body.notMac .tab-group {
 .navbar-action-button {
 	padding: 1em;
 }
-
 .navbar-action-button + .navbar-action-button {
 	padding-left: 0.5em;
 }
@@ -182,65 +181,6 @@ body.notMac .tab-group {
 	display: none;
 }
 .tab-item.jshover .tab-close-button {
-	display: inline-block;
-}
-
-/* expanded mode */
-
-body.is-expanded-mode .tab-group {
-	min-height: 125px;
-	max-height: 600px;
-	padding-top: 40px;
-	padding-left: 1em;
-	overflow: hidden;
-}
-body.is-expanded-mode #tabs {
-	flex-wrap: wrap;
-	max-height: 100vh;
-	width: calc(100% - 20px) !important;
-}
-body.is-expanded-mode .tab-item {
-	min-width: 300px;
-	max-width: 350px;
-	height: 90px;
-	cursor: pointer;
-	padding: 0.5em;
-	transition: none;
-}
-body.is-expanded-mode .tab-item .tab-view-contents {
-	line-height: 1.25em;
-	word-break: normal;
-}
-body.is-expanded-mode .tab-item .secondary-text {
-	display: block;
-	font-size: 0.8em;
-	line-height: 1em;
-	opacity: 0.75;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
-}
-body.is-expanded-mode .tab-item i {
-	display: none !important;
-}
-body.is-expanded-mode #add-tab-button {
-	display: none;
-}
-@media all and (max-width: 650px) {
-	body.is-expanded-mode .tab-item {
-		min-width: 50%;
-		max-width: 50%;
-	}
-}
-@media all and (max-width: 450px) {
-	body.is-expanded-mode .tab-item {
-		min-width: 100%;
-		max-width: 100%;
-	}
-}
-body.is-expanded-mode .tab-item .tab-view-contents .title {
-	max-height: 2.9em;
-	overflow: hidden;
 	display: inline-block;
 }
 

--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -189,7 +189,7 @@ body.notMac .tab-group {
 body.is-focus-mode .tab-item:not(.active) {
 	display: none;
 }
-body.is-focus-mode #add-tab-button {
+body.is-focus-mode .navbar-action-button {
 	display: none;
 }
 

--- a/css/navbarTabs.css
+++ b/css/navbarTabs.css
@@ -152,8 +152,12 @@ body.notMac .tab-group {
 
 /* buttons */
 
-#add-tab-button {
+.navbar-action-button {
 	padding: 1em;
+}
+
+.navbar-action-button + .navbar-action-button {
+	padding-left: 0.5em;
 }
 
 /* reader button */

--- a/css/searchbar.css
+++ b/css/searchbar.css
@@ -7,7 +7,7 @@
 	background: #fff;
 	color: #000;
 	padding-left: 75px;
-	padding-right: 45px;
+	padding-right: 82px;
 	/* align with window controls */
 	-webkit-user-select: none;
 	max-height: calc(100% - 75px);

--- a/css/searchbar.css
+++ b/css/searchbar.css
@@ -41,11 +41,11 @@ body.notMac #searchbar {
 	background-color: rgba(0, 0, 0, 0.08);
 	outline: none;
 }
-.dark-theme .searchbar-item:hover {
+.dark-theme .theme-background-color .searchbar-item:hover {
 	background-color: rgba(255, 255, 255, 0.08);
 }
-.dark-theme .searchbar-item:focus,
-.dark-theme .searchbar-item.fakefocus {
+.dark-theme .theme-background-color .searchbar-item:focus,
+.dark-theme .theme-background-color .searchbar-item.fakefocus {
 	background-color: rgba(255, 255, 255, 0.14);
 }
 .searchbar-item .title {
@@ -69,7 +69,7 @@ body.notMac #searchbar {
 	width: 1em;
 	height: 1em;
 }
-.dark-theme .searchbar-item i {
+.dark-theme .theme-background-color .searchbar-item i {
 	opacity: 0.33;
 }
 
@@ -209,9 +209,9 @@ body.is-edit-mode webview {
 .searchbar-item.tag:focus {
 	background: rgba(0, 0, 0, 0.08);
 }
-.dark-theme .searchbar-item.tag {
+.dark-theme .theme-background-color .searchbar-item.tag {
 	background-color: rgba(255, 255, 255, 0.08);
 }
-.dark-theme .searchbar-item.tag:focus {
+.dark-theme .theme-background-color .searchbar-item.tag:focus {
 	background-color: rgba(255, 255, 255, 0.12);
 }

--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -31,11 +31,6 @@
 	transform: none;
 	transition: 0.15s all;
 }
-@media all and (max-width: 600px) {
-	#task-overlay {
-		padding: 10% 5%;
-	}
-}
 #task-overlay[hidden] {
 	display: block !important;
 	visibility: hidden;
@@ -75,7 +70,6 @@
 	text-align: center;
 	color: inherit;
 	background-color: rgb(245, 245, 245);
-	margin-top: 2em;
 	cursor: pointer;
 }
 #add-task:hover {
@@ -89,4 +83,13 @@
 	display: flex;
 	align-items: center;
 	padding-right: 1em;
+}
+@media all and (max-width: 600px) {
+	#task-overlay {
+		padding: 10% 5% 5em 5%;
+	}
+	#add-task {
+		width: 90%;
+		left: 5%;
+	}
 }

--- a/css/taskOverlay.css
+++ b/css/taskOverlay.css
@@ -1,0 +1,92 @@
+.navbar {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 2.3333em;
+	background-color: inherit;
+	z-index: 1;
+	border-bottom: 1px rgba(0, 0, 0, 0.1) solid;
+}
+#switch-task-button {
+	position: absolute;
+	top: -0.375em;
+	right: 0;
+	z-index: 999999;
+}
+#switch-task-button.active {
+	color: royalblue !important;
+}
+#task-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: #fff;
+	padding: 10%;
+	white-space: nowrap;
+	overflow: auto;
+	opacity: 1;
+	transform: none;
+	transition: 0.15s all;
+}
+@media all and (max-width: 600px) {
+	#task-overlay {
+		padding: 10% 5%;
+	}
+}
+#task-overlay[hidden] {
+	display: block !important;
+	visibility: hidden;
+	transform: scale(1.1);
+	opacity: 0;
+}
+#task-overlay:not(.notMac):not(.fullscreen) {
+	padding-top: 40px;
+}
+.task-container + .task-container {
+	padding-top: 0.75em;
+}
+
+/* inputs */
+
+.task-name {
+	-webkit-appearance: none;
+	appearance: none;
+	flex: 1;
+	font-size: 1.2em;
+	color: inherit;
+	border: 0;
+	background: none;
+	opacity: 0.75;
+	margin: 0.5em;
+}
+.task-name::-webkit-input-placeholder {
+	color: inherit;
+	opacity: 0.8;
+}
+#add-task {
+	position: fixed;
+	bottom: 0;
+	left: 10%;
+	width: 80%;
+	padding: 1.25em;
+	text-align: center;
+	color: inherit;
+	background-color: rgb(245, 245, 245);
+	margin-top: 2em;
+	cursor: pointer;
+}
+#add-task:hover {
+	background-color: rgb(235, 235, 235);
+}
+#add-task .fa {
+	opacity: 0.75;
+	margin-right: 0.25em;
+}
+.task-action-container {
+	display: flex;
+	align-items: center;
+	padding-right: 1em;
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
 	<link rel="stylesheet" href="css/base.css" />
 	<link rel="stylesheet" href="css/navbarTabs.css" />
+	<link rel="stylesheet" href="css/taskOverlay.css" />
 	<link rel="stylesheet" href="css/webviews.css" />
 	<link rel="stylesheet" href="css/searchbar.css" />
 	<link rel="stylesheet" href="ext/font-awesome-4.4.0/css/font-awesome.min.css" />
@@ -17,9 +18,12 @@
 
 <body>
 
+	<i id="switch-task-button" class="fa fa-bars navbar-action-button theme-text-color" title="View Tasks"></i>
+
 	<div class="tab-group theme-background-color theme-text-color" tabindex="-1">
 		<div id="tabs"></div>
-		<i id="add-tab-button" class="fa fa-plus" title="New Tab"></i>
+			<i id="add-tab-button" class="fa fa-plus navbar-action-button" title="New Tab"></i>
+			<i class="fa fa-bars navbar-action-button invisible"></i>
 	</div>
 
 	<div class="theme-background-color theme-text-color" id="searchbar">
@@ -41,9 +45,17 @@
 		<i class="icon fa fa-close" id="findinpage-end"></i>
 	</div>
 
+	<div id="task-overlay" class="" hidden>
+		<div class="navbar"></div>
+		<div id="task-area"></div>
+		<div id="add-task">
+			<i class="fa fa-pencil-square-o"></i> New Task
+		</div>
+	</div>
+
 	<!-- add scripts in Gruntfile.js -->
 
-	<script src="dist/build.min.js"></script>
+	<script src="dist/build.js"></script>
 
 	<link rel="stylesheet" href="css/findinpage.css" />
 

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 	</div>
 
 	<div id="task-overlay" class="" hidden>
-		<div class="navbar"></div>
+		<div class="navbar" id="task-overlay-navbar"></div>
 		<div id="task-area"></div>
 		<div id="add-task">
 			<i class="fa fa-pencil-square-o"></i> New Task

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -93,7 +93,7 @@ function switchToTab(id, options) {
 	setActiveTabElement(id);
 	switchToWebview(id);
 
-	if (options.focusWebview != false && !isExpandedMode) { //trying to focus a webview while in expanded mode breaks the page
+	if (options.focusWebview != false) {
 		getWebview(id).focus();
 	}
 

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -14,6 +14,16 @@ function navigate(tabId, newURL) {
 	});
 }
 
+function destroyTask(id) {
+	var task = tasks.get(id);
+
+	task.tabs.forEach(function (tab) {
+		destroyWebview(tab.id);
+	});
+
+	tasks.destroy(id);
+}
+
 //destroys the webview and tab element for a tab
 function destroyTab(id) {
 
@@ -48,6 +58,20 @@ function closeTab(tabId) {
 
 	} else {
 		destroyTab(tabId);
+	}
+}
+
+function switchToTask(id) {
+	tasks.setSelected(id);
+
+	rerenderTabstrip();
+
+	var taskData = tasks.get(id);
+
+	if (taskData.tabs.length > 0) {
+		switchToTab(taskData.tabs.getSelected());
+	} else {
+		addTab();
 	}
 }
 

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -129,8 +129,9 @@ require.async("mousetrap", function (Mousetrap) {
 	})
 
 	Mousetrap.bind("esc", function (e) {
+		taskOverlay.hide();
+
 		leaveTabEditMode();
-		leaveExpandedMode();
 		if (findinpage.isEnabled) {
 			findinpage.end(); //this also focuses the webview
 		} else {
@@ -160,8 +161,6 @@ require.async("mousetrap", function (Mousetrap) {
 
 	Mousetrap.bind(["option+mod+left", "shift+ctrl+tab"], function (d) {
 
-		enterExpandedMode(); //show the detailed tab switcher
-
 		var currentIndex = tabs.getIndex(tabs.getSelected());
 		var previousTab = tabs.getAtIndex(currentIndex - 1);
 
@@ -173,8 +172,6 @@ require.async("mousetrap", function (Mousetrap) {
 	});
 
 	Mousetrap.bind(["option+mod+right", "ctrl+tab"], function (d) {
-
-		enterExpandedMode();
 
 		var currentIndex = tabs.getIndex(tabs.getSelected());
 		var nextTab = tabs.getAtIndex(currentIndex + 1);
@@ -196,20 +193,11 @@ require.async("mousetrap", function (Mousetrap) {
 		addTab(); //create a new, blank tab
 	});
 
-	//return exits expanded mode
-
-	Mousetrap.bind("return", function () {
-		if (isExpandedMode) {
-			leaveExpandedMode();
-			getWebview(tabs.getSelected()).focus();
-		}
-	});
-
 	Mousetrap.bind("shift+mod+e", function () {
-		if (!isExpandedMode) {
-			enterExpandedMode();
+		if (taskOverlay.isShown) {
+			taskOverlay.hide();
 		} else {
-			leaveExpandedMode();
+			taskOverlay.show();
 		}
 	});
 
@@ -236,9 +224,3 @@ require.async("mousetrap", function (Mousetrap) {
 	});
 
 }); //end require mousetrap
-
-document.body.addEventListener("keyup", function (e) {
-	if (e.keyCode == 17) { //ctrl key
-		leaveExpandedMode();
-	}
-});

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -71,6 +71,21 @@ function addPrivateTab() {
 
 ipc.on("addPrivateTab", addPrivateTab);
 
+ipc.on("addTask", function () {
+	/* new tasks can't be created in focus mode */
+	if (isFocusMode) {
+		showFocusModeError();
+		return;
+	}
+
+	addTaskFromOverlay();
+	taskOverlay.show();
+	setTimeout(function () {
+		taskOverlay.hide();
+		enterEditMode(tabs.getSelected());
+	}, 600);
+});
+
 require.async("mousetrap", function (Mousetrap) {
 	window.Mousetrap = Mousetrap;
 

--- a/js/navbar/navbarTabs.js
+++ b/js/navbar/navbarTabs.js
@@ -16,6 +16,7 @@ function getTabElement(id) { //gets the DOM element for a tab
 }
 
 function setActiveTabElement(tabId) {
+
 	var activeTab = document.querySelector(".tab-item.active");
 
 	if (activeTab) {
@@ -95,6 +96,15 @@ function enterEditMode(tabId) {
 	}
 }
 
+
+//redraws all of the tabs in the tabstrip
+function rerenderTabstrip() {
+	empty(tabGroup);
+	for (var i = 0; i < tabs.length; i++) {
+		tabGroup.appendChild(createTabElement(tabs[i]));
+	}
+}
+
 function rerenderTabElement(tabId) {
 	var tabEl = getTabElement(tabId),
 		tabData = tabs.get(tabId);
@@ -120,13 +130,12 @@ function rerenderTabElement(tabId) {
 	bookmarks.renderStar(tabId);
 }
 
-function createTabElement(tabId) {
-	var data = tabs.get(tabId),
-		url = urlParser.parse(data.url);
+function createTabElement(data) {
+	var url = urlParser.parse(data.url);
 
 	var tabEl = document.createElement("div");
 	tabEl.className = "tab-item";
-	tabEl.setAttribute("data-tab", tabId);
+	tabEl.setAttribute("data-tab", data.id);
 
 	if (data.private) {
 		tabEl.classList.add("private-tab");
@@ -150,13 +159,13 @@ function createTabElement(tabId) {
 	input.value = url;
 
 	ec.appendChild(input);
-	ec.appendChild(bookmarks.getStar(tabId));
+	ec.appendChild(bookmarks.getStar(data.id));
 
 	tabEl.appendChild(ec);
 
 	var vc = document.createElement("div");
 	vc.className = "tab-view-contents";
-	vc.appendChild(readerView.getButton(tabId));
+	vc.appendChild(readerView.getButton(data.id));
 
 	//icons
 
@@ -170,7 +179,7 @@ function createTabElement(tabId) {
 
 	closeTabButton.addEventListener("click", function (e) {
 
-		closeTab(tabId);
+		closeTab(data.id);
 
 		//prevent the searchbar from being opened
 		e.stopPropagation();
@@ -258,10 +267,10 @@ function createTabElement(tabId) {
 		var tabId = this.getAttribute("data-tab");
 
 		//if the tab isn't focused
-		if (tabs.getSelected() != tabId) {
-			switchToTab(tabId);
+		if (tabs.getSelected() != data.id) {
+			switchToTab(data.id);
 		} else if (!isExpandedMode) { //the tab is focused, edit tab instead
-			enterEditMode(tabId);
+			enterEditMode(data.id);
 		}
 
 	});
@@ -329,7 +338,7 @@ function addTab(tabId, options) {
 
 	var index = tabs.getIndex(tabId);
 
-	var tabEl = createTabElement(tabId);
+	var tabEl = createTabElement(tab);
 
 	tabGroup.insertBefore(tabEl, tabGroup.childNodes[index]);
 

--- a/js/navbar/navbarTabs.js
+++ b/js/navbar/navbarTabs.js
@@ -32,19 +32,15 @@ function setActiveTabElement(tabId) {
 		el.classList.remove("has-highlight");
 	}
 
-	if (!isExpandedMode) {
-
-		requestIdleCallback(function () {
-			requestAnimationFrame(function () {
-				el.scrollIntoView({
-					behavior: "smooth"
-				});
+	requestIdleCallback(function () {
+		requestAnimationFrame(function () {
+			el.scrollIntoView({
+				behavior: "smooth"
 			});
-		}, {
-			timeout: 1500
 		});
-
-	}
+	}, {
+		timeout: 1500
+	});
 
 }
 
@@ -66,7 +62,7 @@ function leaveTabEditMode(options) {
 
 function enterEditMode(tabId) {
 
-	leaveExpandedMode();
+	taskOverlay.hide();
 
 	var tabEl = getTabElement(tabId);
 	var webview = getWebview(tabId);
@@ -269,7 +265,7 @@ function createTabElement(data) {
 		//if the tab isn't focused
 		if (tabs.getSelected() != data.id) {
 			switchToTab(data.id);
-		} else if (!isExpandedMode) { //the tab is focused, edit tab instead
+		} else { //the tab is focused, edit tab instead
 			enterEditMode(data.id);
 		}
 
@@ -294,8 +290,6 @@ function createTabElement(data) {
 			}, 150); //wait until the animation has completed
 		}
 	});
-
-	tabEl.addEventListener("mouseenter", handleExpandedModeTabItemHover);
 
 	return tabEl;
 }
@@ -364,7 +358,6 @@ function addTab(tabId, options) {
 //when we click outside the navbar, we leave editing mode
 
 bindWebviewEvent("focus", function () {
-	leaveExpandedMode();
 	leaveTabEditMode();
 	findinpage.end();
 });

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -141,12 +141,16 @@ var tasks = {
 		return task.id;
 	},
 	get: function (id) {
+		if (!id) {
+			return tabState.tasks;
+		}
+
 		for (var i = 0; i < tabState.tasks.length; i++) {
 			if (tabState.tasks[i].id == id) {
 				return tabState.tasks[i];
 			}
 		}
-		return tabState.tasks;
+		return null;
 	},
 	setSelected: function (id) {
 		tabState.selectedTask = id;

--- a/js/tabState.js
+++ b/js/tabState.js
@@ -1,10 +1,9 @@
-/* tracks the state of tabs */
+var tabState = {
+	tasks: [], //each task is {id, name, tabs: [], selectedTab}
+	selectedTask: null,
+};
 
-var tabs = {
-	_state: {
-		tabs: [],
-		selected: null,
-	},
+var tabPrototype = {
 	add: function (tab, index) {
 
 		//make sure the tab exists before we create it
@@ -24,25 +23,25 @@ var tabs = {
 			readerable: tab.readerable || false,
 			backgroundColor: tab.backgroundColor,
 			foregroundColor: tab.foregroundColor,
+			selected: tab.selected || false,
 		}
 
 		if (index) {
-			tabs._state.tabs.splice(index, 0, newTab);
+			this.splice(index, 0, newTab);
 		} else {
-			tabs._state.tabs.push(newTab);
+			this.push(newTab);
 		}
-
 
 		return tabId;
 
 	},
 	update: function (id, data) {
-		if (!tabs.get(id)) {
+		if (!this.get(id)) {
 			throw new ReferenceError("Attempted to update a tab that does not exist.");
 		}
 		var index = -1;
-		for (var i = 0; i < tabs._state.tabs.length; i++) {
-			if (tabs._state.tabs[i].id == id) {
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].id == id) {
 				index = i;
 			}
 		}
@@ -50,13 +49,13 @@ var tabs = {
 			if (data[key] == undefined) {
 				throw new ReferenceError("Key " + key + " is undefined.");
 			}
-			tabs._state.tabs[index][key] = data[key];
+			this[index][key] = data[key];
 		}
 	},
 	destroy: function (id) {
-		for (var i = 0; i < tabs._state.tabs.length; i++) {
-			if (tabs._state.tabs[i].id == id) {
-				tabs._state.tabs.splice(i, 1);
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].id == id) {
+				this.splice(i, 1);
 				return i;
 			}
 		}
@@ -66,46 +65,107 @@ var tabs = {
 		if (!id) { //no id provided, return an array of all tabs
 			//it is important to deep-copy the tab objects when returning them. Otherwise, the original tab objects get modified when the returned tabs are modified (such as when processing a url).
 			var tabsToReturn = [];
-			for (var i = 0; i < tabs._state.tabs.length; i++) {
-				tabsToReturn.push(JSON.parse(JSON.stringify(tabs._state.tabs[i])));
+			for (var i = 0; i < this.length; i++) {
+				tabsToReturn.push(JSON.parse(JSON.stringify(this[i])));
 			}
 			return tabsToReturn;
 		}
-		for (var i = 0; i < tabs._state.tabs.length; i++) {
-			if (tabs._state.tabs[i].id == id) {
-				return tabs._state.tabs[i]
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].id == id) {
+				return this[i]
 			}
 		}
 		return undefined;
 	},
 	getIndex: function (id) {
-		for (var i = 0; i < tabs._state.tabs.length; i++) {
-			if (tabs._state.tabs[i].id == id) {
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].id == id) {
 				return i;
 			}
 		}
 		return -1;
 	},
 	getSelected: function () {
-		return tabs._state.selected;
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].selected) {
+				return this[i].id;
+			}
+		}
+		return null;
 	},
 	getAtIndex: function (index) {
-		return tabs._state.tabs[index] || undefined;
+		return this[index] || undefined;
 	},
 	setSelected: function (id) {
-		if (!tabs.get(id)) {
+		if (!this.get(id)) {
 			throw new ReferenceError("Attempted to select a tab that does not exist.");
 		}
-		tabs._state.selected = id;
+		for (var i = 0; i < this.length; i++) {
+			if (this[i].id == id) {
+				this[i].selected = true;
+			} else {
+				this[i].selected = false;
+			}
+		}
 	},
 	count: function () {
-		return tabs._state.tabs.length;
+		return this.length;
 	},
 	reorder: function (newOrder) { //newOrder is an array of [tabId, tabId] that indicates the order that tabs should be in
-		tabs._state.tabs.sort(function (a, b) {
+		this.sort(function (a, b) {
 			return newOrder.indexOf(a.id) - newOrder.indexOf(b.id);
 		});
 	},
+}
+
+function getRandomId() {
+	return Math.round(Math.random() * 100000000000000000);
+}
+
+var tasks = {
+	add: function (name, id) {
+		var task = {};
+
+		task.id = id || getRandomId();
+		task.name = name || null;
+		task.tabs = [];
+		task.selectedTab = null;
+
+		//task.currentTask.tabs.__proto__ = tabPrototype;
+
+		for (var key in tabPrototype) {
+			task.tabs.__proto__[key] = tabPrototype[key];
+		}
+
+		tabState.tasks.push(task);
+		return task.id;
+	},
+	get: function (id) {
+		for (var i = 0; i < tabState.tasks.length; i++) {
+			if (tabState.tasks[i].id == id) {
+				return tabState.tasks[i];
+			}
+		}
+		return tabState.tasks;
+	},
+	setSelected: function (id) {
+		tabState.selectedTask = id;
+		window.currentTask = tasks.get(id);
+		window.tabs = currentTask.tabs;
+	},
+	destroy: function (id) {
+		for (var i = 0; i < tabState.tasks.length; i++) {
+			if (tabState.tasks[i].id == id) {
+				tabState.tasks.splice(i, 1);
+				return i;
+			}
+		}
+		return false;
+	},
+}
+
+function getSelectedTask() {
+	return getTask(tabState.selectedTask);
 }
 
 function isEmpty(tabList) {

--- a/js/taskOverlay.js
+++ b/js/taskOverlay.js
@@ -1,0 +1,163 @@
+function addTaskFromOverlay() {
+	tasks.setSelected(tasks.add());
+	rerenderTabstrip();
+	taskOverlay.hide();
+	addTab();
+}
+
+var overlay = document.getElementById("task-overlay");
+var taskContainer = document.getElementById("task-area");
+var taskSwitcherButton = document.getElementById("switch-task-button");
+var addTaskButton = document.getElementById("add-task");
+
+taskSwitcherButton.addEventListener("click", function () {
+	taskOverlay.toggle();
+});
+
+addTaskButton.addEventListener("click", function (e) {
+	switchToTask(tasks.add());
+	taskOverlay.hide();
+});
+
+function getTaskOverlayTabElement(tab, task) {
+
+	var item = createSearchbarItem({
+		title: tab.title || "New Tab",
+		secondaryText: urlParser.removeProtocol(tab.url),
+		classList: ["task-tab-item"],
+		delete: function () {
+			task.tabs.destroy(tab.id);
+			destroyWebview(tab.id);
+
+			//if there are no tabs left, remove the task
+
+			if (task.tabs.count() == 0) {
+				destroyTask(task.id);
+				if (tasks.get().length == 0) {
+					addTaskFromOverlay();
+				} else {
+					//re-render the overlay to remove the task element
+					taskOverlay.show();
+				}
+			}
+		},
+	});
+
+	item.setAttribute("data-tab", tab.id);
+
+	return item;
+}
+
+function getTaskElement(task, taskIndex) {
+	var container = document.createElement("div");
+	container.className = "task-container";
+
+	var taskActionContainer = document.createElement("div");
+	taskActionContainer.className = "task-action-container";
+
+	//add the input for the task name
+
+	var input = document.createElement("input");
+	input.classList.add("task-name");
+
+	input.placeholder = "Task " + (taskIndex + 1);
+
+	input.value = task.name || "Task " + (taskIndex + 1);
+
+	input.addEventListener("keyup", function (e) {
+		if (e.keyCode == 13) {
+			this.blur();
+		}
+
+		tasks.get(task.id).name = this.value;
+	});
+
+	input.addEventListener("focus", function () {
+		this.select();
+	});
+
+	taskActionContainer.appendChild(input);
+
+	//delete button
+
+	var deleteButton = document.createElement("i");
+	deleteButton.className = "fa fa-trash-o";
+
+	deleteButton.addEventListener("click", function (e) {
+		destroyTask(task.id);
+		container.remove();
+
+		if (tasks.get().length == 0) { //create a new task
+			addTaskFromOverlay();
+		}
+	});
+
+	taskActionContainer.appendChild(deleteButton);
+
+	container.appendChild(taskActionContainer);
+
+	if (task.tabs) {
+		for (var i = 0; i < task.tabs.length; i++) {
+
+			var el = getTaskOverlayTabElement(task.tabs[i], task);
+
+			el.addEventListener("click", function (e) {
+				switchToTask(task.id);
+				switchToTab(this.getAttribute("data-tab"));
+
+				taskOverlay.hide();
+			});
+
+			container.appendChild(el);
+		}
+	}
+
+	return container;
+}
+
+var taskOverlay = {
+	isShown: false,
+	show: function () {
+
+		taskOverlay.isShown = true;
+
+		leaveTabEditMode();
+
+		taskSwitcherButton.classList.add("active");
+
+		empty(taskContainer);
+
+		//show the task elements
+		tasks.get().forEach(function (task, index) {
+			taskContainer.appendChild(getTaskElement(task, index));
+		});
+
+		//scroll to the selected element and focus it
+
+		var currentTabElement = document.querySelector('.task-tab-item[data-tab="{id}"]'.replace("{id}", currentTask.tabs.getSelected()));
+
+		if (currentTabElement) {
+			currentTabElement.scrollIntoViewIfNeeded();
+			currentTabElement.classList.add("fakefocus");
+		}
+
+		//un-hide the overlay
+
+		overlay.hidden = false;
+	},
+	hide: function () {
+		if (taskOverlay.isShown) {
+			taskOverlay.isShown = false;
+			overlay.hidden = true;
+
+			taskSwitcherButton.classList.remove("active");
+		}
+	},
+	toggle: function () {
+		if (taskOverlay.isShown) {
+			taskOverlay.hide();
+		} else {
+			taskOverlay.show();
+		}
+	}
+}

--- a/js/taskOverlay.js
+++ b/js/taskOverlay.js
@@ -132,6 +132,12 @@ var taskOverlay = {
 	}),
 	show: function () {
 
+		/* disabled in focus mode */
+		if (isFocusMode) {
+			showFocusModeError();
+			return;
+		}
+
 		leaveTabEditMode();
 
 		taskOverlay.isShown = true;

--- a/js/taskOverlay.js
+++ b/js/taskOverlay.js
@@ -10,6 +10,7 @@ var overlay = document.getElementById("task-overlay");
 var taskContainer = document.getElementById("task-area");
 var taskSwitcherButton = document.getElementById("switch-task-button");
 var addTaskButton = document.getElementById("add-task");
+var navbar = document.getElementById("task-overlay-navbar");
 
 taskSwitcherButton.addEventListener("click", function () {
 	taskOverlay.toggle();
@@ -17,6 +18,10 @@ taskSwitcherButton.addEventListener("click", function () {
 
 addTaskButton.addEventListener("click", function (e) {
 	switchToTask(tasks.add());
+	taskOverlay.hide();
+});
+
+navbar.addEventListener("click", function () {
 	taskOverlay.hide();
 });
 

--- a/js/webviews.js
+++ b/js/webviews.js
@@ -245,6 +245,8 @@ function addWebview(tabId) {
 	webview.classList.add("hidden");
 
 	webviewBase.appendChild(webview);
+
+	return webview;
 }
 
 function switchToWebview(id) {
@@ -254,6 +256,11 @@ function switchToWebview(id) {
 	}
 
 	var wv = getWebview(id);
+
+	if (!wv) {
+		wv = addWebview(id);
+	}
+
 	wv.classList.remove("hidden");
 	wv.hidden = false;
 }
@@ -264,7 +271,9 @@ function updateWebview(id, url) {
 
 function destroyWebview(id) {
 	var w = document.querySelector('webview[data-tab="{id}"]'.replace("{id}", id));
-	w.parentNode.removeChild(w);
+	if (w) {
+		w.parentNode.removeChild(w);
+	}
 }
 
 function getWebview(id) {

--- a/main/main.js
+++ b/main/main.js
@@ -145,6 +145,13 @@ function createAppMenu() {
 					}
       },
 				{
+					label: 'New Task',
+					accelerator: 'shift+CmdOrCtrl+n',
+					click: function (item, window) {
+						sendIPCToWindow(window, "addTask");
+					}
+      },
+				{
 					type: "separator"
       },
 				{


### PR DESCRIPTION
Fixes #5.

This adds the ability to have multiple groups of tabs, called "tasks", open at the same time, and to switch between them (similar to the tab groups feature in Firefox).

Screenshots:

<img width="1439" alt="screen shot 2016-04-24" src="https://cloud.githubusercontent.com/assets/10314059/14771739/98228f60-0a59-11e6-9c84-1ff3d73c7ba7.png">
<img width="1439" alt="screen shot 2016-04-24" src="https://cloud.githubusercontent.com/assets/10314059/14771738/9820f862-0a59-11e6-9271-95fde045f398.png">

From the tab overlay, dragging and dropping tabs between tasks and renaming tasks is also supported.